### PR TITLE
Fix portal when parent component is removed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ const usePortal = ({
       clickOutsideToHide ? handleHide : undefined,
       escToHide ? handleHide : undefined
     ),
-    [internalShowHide && isShow]
+    [internalShowHide, isShow]
   );
 
   return { Portal, isShow, show, hide, toggle };


### PR DESCRIPTION
When `usePortal` was used multiple times on a page and one of the components was removed (say with setTimeout), it didn't re-bind container and never shown second portal.

Current workaround is to use unique ID for each portal on a page, but that isn't optimal.

I am pretty sure this is a typo, but I can produce a codesandbox if you need.
